### PR TITLE
Fixed errors in JavaDoc that caused build to fail under Java 8

### DIFF
--- a/reactor-spring-context/src/main/java/reactor/spring/context/annotation/Selector.java
+++ b/reactor-spring-context/src/main/java/reactor/spring/context/annotation/Selector.java
@@ -29,10 +29,11 @@ import java.lang.annotation.*;
 public @interface Selector {
 
 	/**
-	 * An expression that evaluates to a {@link reactor.event.selector.Selector} to register this handler with the {@link
+	 * An expression that evaluates to a {@link reactor.event.selector.Selector} to register
+     * this handler with the {@link
 	 * reactor.core.Reactor}.
 	 * If empty, consumer will be subscribed on the global reactor selector
-	 * {@link reactor.core.Reactor#on(reactor.function.Consumer)}
+	 * {@link reactor.core.Reactor#on(reactor.event.selector.Selector selector, reactor.function.Consumer)}
 	 *
 	 * @return An expression to be evaluated.
 	 */

--- a/reactor-spring-messaging/src/main/java/reactor/spring/messaging/factory/net/NetServerFactoryBean.java
+++ b/reactor-spring-messaging/src/main/java/reactor/spring/messaging/factory/net/NetServerFactoryBean.java
@@ -132,7 +132,6 @@ public class NetServerFactoryBean implements FactoryBean<NetServer>, SmartLifecy
 	 * <li>{@code string} - Use the standard String codec.</li>
 	 * <li>{@code syslog} - Use the standard Syslog codec.</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param codec
 	 * 		the codec
@@ -161,7 +160,6 @@ public class NetServerFactoryBean implements FactoryBean<NetServer>, SmartLifecy
 	 * <li>{@code length} - Means use a length-field based codec where the initial bytes of a message are the length of
 	 * the rest of the message.</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param framing
 	 * 		type of framing
@@ -181,7 +179,6 @@ public class NetServerFactoryBean implements FactoryBean<NetServer>, SmartLifecy
 	 * <li>{@code LF} - Means use a line feed \\n.</li>
 	 * <li>{@code CR} - Means use a carriage return \\r.</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param delimiter
 	 * 		the delimiter to use
@@ -212,7 +209,6 @@ public class NetServerFactoryBean implements FactoryBean<NetServer>, SmartLifecy
 	 * <li>{@code tcp} - Use the built-in Netty TCP support.</li>
 	 * <li>{@code udp} - Use the built-in Netty UDP support.</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param transport
 	 * 		the transport to use


### PR DESCRIPTION
See additional info [here](http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html)
