### PR TITLE
Make configuration of Spring IO plugin less invasive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,18 @@ subprojects { subproject ->
 	apply plugin: 'java'
 	apply plugin: 'groovy'
 	apply plugin: 'maven'
-	apply plugin: 'spring-io'
+
+	if (project.hasProperty('platformVersion')) {
+		apply plugin: 'spring-io'
+
+		repositories {
+			maven { url 'http://repo.spring.io/libs-snapshot' }
+		}
+
+		dependencies {
+			springIoVersions "io.spring.platform:platform-versions:$platformVersion@properties"
+		}
+	}
 
 	sourceCompatibility = 1.7
 	targetCompatibility = 1.7


### PR DESCRIPTION
The plugin is now only applied when the build is run with the platformVersion property. This property is also used to determine the version of the platform-versions dependency that will be used by the springIoCheck task. This breaks a circular dependency between the projects that are included in the Platform and the Platform itself.
