### PR TITLE
New annotations target for @Selector and @ReplyTo

### DIFF
--- a/reactor-spring-context/src/main/java/reactor/spring/context/annotation/ReplyTo.java
+++ b/reactor-spring-context/src/main/java/reactor/spring/context/annotation/ReplyTo.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * @author Jon Brisbin
  * @author Stephane Maldini
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface ReplyTo {

--- a/reactor-spring-context/src/main/java/reactor/spring/context/annotation/Selector.java
+++ b/reactor-spring-context/src/main/java/reactor/spring/context/annotation/Selector.java
@@ -23,7 +23,7 @@ import java.lang.annotation.*;
  * @author Jon Brisbin
  * @author Stephane Maldini
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface Selector {


### PR DESCRIPTION
New annotations target (ANNOTATION_TYPE) in order to allow the creation of stereotypes for @Selector and **@ReplyTo**.

With that modification, we can write something like : 

``` java
@Target(ElementType.METHOD)
@Retention(RetentionPolicy.RUNTIME)
@Selector(value = "test", eventBus = "@rootEventBus")
public @interface TestSelector {}
```
