### PR TITLE
Issue #12: Adding missing 'return' statement

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 06 08:52:49 CDT 2014
+#Tue Jun 23 12:07:39 BST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip

--- a/reactor-spring-context/src/main/java/reactor/spring/context/config/ConsumerBeanAutoConfiguration.java
+++ b/reactor-spring-context/src/main/java/reactor/spring/context/config/ConsumerBeanAutoConfiguration.java
@@ -346,7 +346,7 @@ public class ConsumerBeanAutoConfiguration implements ApplicationListener<Contex
 
 			if (!argTypes[0].isAssignableFrom(ev.getClass())
 					&& conversionService.canConvert(ev.getClass(), argTypes[0])) {
-				ReflectionUtils.invokeMethod(method, bean, conversionService.convert(ev, argTypes[0]));
+				return ReflectionUtils.invokeMethod(method, bean, conversionService.convert(ev, argTypes[0]));
 			}
 
 			if (conversionService.canConvert(ev.getData().getClass(), argTypes[0])) {

--- a/reactor-spring-context/src/test/groovy/reactor/spring/context/config/ConsumerBeanAutoConfigurationSpec.groovy
+++ b/reactor-spring-context/src/test/groovy/reactor/spring/context/config/ConsumerBeanAutoConfigurationSpec.groovy
@@ -32,12 +32,8 @@ import reactor.spring.context.annotation.Selector
 import reactor.spring.context.annotation.SelectorType
 import spock.lang.Specification
 
-import java.text.DateFormat
-import java.text.SimpleDateFormat
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-
-import static reactor.bus.selector.Selectors.$
 
 /**
  * @author Jon Brisbin

--- a/reactor-spring-context/src/test/groovy/reactor/spring/context/config/ConsumerBeanAutoConfigurationSpec.groovy
+++ b/reactor-spring-context/src/test/groovy/reactor/spring/context/config/ConsumerBeanAutoConfigurationSpec.groovy
@@ -15,20 +15,29 @@
  */
 package reactor.spring.context.config
 
+import groovy.transform.EqualsAndHashCode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.ConversionService
+import org.springframework.core.convert.converter.Converter
+import org.springframework.core.convert.support.DefaultConversionService
 import reactor.Environment
 import reactor.bus.Event
 import reactor.bus.EventBus
 import reactor.spring.context.annotation.Consumer
+import reactor.spring.context.annotation.ReplyTo
 import reactor.spring.context.annotation.Selector
 import reactor.spring.context.annotation.SelectorType
 import spock.lang.Specification
 
+import java.text.DateFormat
+import java.text.SimpleDateFormat
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+
+import static reactor.bus.selector.Selectors.$
 
 /**
  * @author Jon Brisbin
@@ -54,6 +63,29 @@ class ConsumerBeanAutoConfigurationSpec extends Specification {
 
 	}
 
+    def "Annotated Consumer with custom type is wired and the selector method is invoked after converting the value"() {
+
+        given:
+            "an ApplicationContext with an annotated bean handler"
+            def appCtx = new AnnotationConfigApplicationContext(AnnotatedHandlerConfig)
+            def handlerBean = appCtx.getBean(HandlerBean)
+            def reactor = appCtx.getBean(EventBus)
+
+        when:
+            "an Event is emitted onto the Reactor in context"
+            reactor.send('customEvent.sink', Event.wrap("Hello").setReplyTo('customEventReply.sink'))
+
+        then:
+            "the method has been invoked"
+            handlerBean.latch.await(1, TimeUnit.SECONDS)
+
+    }
+
+}
+
+@EqualsAndHashCode
+class CustomEvent {
+    String data
 }
 
 @Consumer
@@ -67,6 +99,36 @@ class HandlerBean {
 		//println "a=${ev.headers['a']}, b=${ev.headers['b']}"
 		latch.countDown()
 	}
+
+    @Selector(value = 'customEvent.sink')
+    @ReplyTo(value = 'customEventReply.sink')
+    CustomEvent handleCustomEvent(CustomEvent customEvent) {
+        return new CustomEvent(data: customEvent.data + " from custom event.")
+    }
+
+    @Selector('customEventReply.sink')
+    void handleReplyToCustomEvent(Event<String> ev) {
+        println "Received response: ${ev.data}"
+        latch.countDown()
+    }
+}
+
+class EventToCustomEventConverter implements Converter<Event, CustomEvent> {
+
+    @Override
+    CustomEvent convert(Event source) {
+        return new CustomEvent(data: source.getData().toString())
+    }
+
+}
+
+class CustomEventToEventConverter implements Converter<CustomEvent, Event> {
+
+    @Override
+    Event convert(CustomEvent source) {
+        return Event.wrap(source.data)
+    }
+
 }
 
 @Configuration
@@ -91,5 +153,13 @@ class AnnotatedHandlerConfig {
 	HandlerBean handlerBean() {
 		return new HandlerBean()
 	}
+
+    @Bean
+	ConversionService reactorConversionService() {
+        DefaultConversionService defaultConversionService = new DefaultConversionService()
+        defaultConversionService.addConverter(Event, CustomEvent, new EventToCustomEventConverter())
+        defaultConversionService.addConverter(CustomEvent, Event, new CustomEventToEventConverter())
+        return defaultConversionService;
+    }
 
 }


### PR DESCRIPTION
Adding the missing 'return' statement in the ConsumerBeanAutoConfiguration#Invoker#apply method. Added Spock test to verify that the conversion is actually done.