### PR TITLE
Exceptions thrown by event handlers are handled by event's errorConsumer

### DIFF
--- a/reactor-spring-context/src/main/java/reactor/spring/context/config/ConsumerBeanAutoConfiguration.java
+++ b/reactor-spring-context/src/main/java/reactor/spring/context/config/ConsumerBeanAutoConfiguration.java
@@ -266,7 +266,14 @@ public class ConsumerBeanAutoConfiguration implements ApplicationListener<Contex
 
 		@Override
 		public void accept(Event ev) {
-			Object result = handler.apply(ev);
+			Object result = null;
+			try {
+				result = handler.apply(ev);
+			} catch (Exception ex) {
+				if(ev.getErrorConsumer() != null) {
+					ev.consumeError(ex);
+				}
+			}
 			Object _replyToKey = replyToKey != null ? replyToKey : ev.getReplyTo();
 			if (_replyToKey != null) {
 				reactor.notify(_replyToKey, Event.wrap(result));


### PR DESCRIPTION
In spring integration if event handler in the Consumer class throws Runtime exception try to use event's error consumer. 
