### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,17 +47,17 @@ ext {
 	jacocoVersion = '0.7.0.201403182114'
 
 	javadocLinks = [
-			"http://docs.oracle.com/javase/7/docs/api/",
-			"http://docs.oracle.com/javaee/6/api/",
-			"http://reactor.github.io/docs/api/",
-			"http://fasterxml.github.com/jackson-core/javadoc/2.3.2/",
-			"http://docs.spring.io/spring/docs/4.0.x/javadoc-api/"
+			"https://docs.oracle.com/javase/7/docs/api/",
+			"https://docs.oracle.com/javaee/6/api/",
+			"https://reactor.github.io/docs/api/",
+			"https://fasterxml.github.com/jackson-core/javadoc/2.3.2/",
+			"https://docs.spring.io/spring/docs/4.0.x/javadoc-api/"
 	] as String[]
 }
 
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
 		classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',
@@ -84,8 +84,8 @@ subprojects { subproject ->
 	group = 'io.projectreactor.spring'
 	repositories {
 		mavenLocal()
-		maven { url 'http://repo.spring.io/libs-snapshot' }
-		maven { url 'http://repo.spring.io/libs-milestone' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-milestone' }
 		mavenCentral()
 	}
 
@@ -93,7 +93,7 @@ subprojects { subproject ->
 		apply plugin: 'spring-io'
 
 		repositories {
-			maven { url 'http://repo.spring.io/libs-milestone' }
+			maven { url 'https://repo.spring.io/libs-milestone' }
 		}
 
 		dependencyManagement {

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -61,12 +61,12 @@ def customizePom(def pom, def gradleProject) {
 			url = 'https://github.com/reactor/reactor-spring'
 			organization {
 				name = 'reactor'
-				url = 'http://github.com/reactor'
+				url = 'https://github.com/reactor'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://reactor.github.io/docs/api/ (404) migrated to:  
  https://reactor.github.io/docs/api/ ([https](https://reactor.github.io/docs/api/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javaee/6/api/ migrated to:  
  https://docs.oracle.com/javaee/6/api/ ([https](https://docs.oracle.com/javaee/6/api/) result 200).
* http://docs.oracle.com/javase/7/docs/api/ migrated to:  
  https://docs.oracle.com/javase/7/docs/api/ ([https](https://docs.oracle.com/javase/7/docs/api/) result 200).
* http://docs.spring.io/spring/docs/4.0.x/javadoc-api/ migrated to:  
  https://docs.spring.io/spring/docs/4.0.x/javadoc-api/ ([https](https://docs.spring.io/spring/docs/4.0.x/javadoc-api/) result 200).
* http://github.com/reactor migrated to:  
  https://github.com/reactor ([https](https://github.com/reactor) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://fasterxml.github.com/jackson-core/javadoc/2.3.2/ migrated to:  
  https://fasterxml.github.com/jackson-core/javadoc/2.3.2/ ([https](https://fasterxml.github.com/jackson-core/javadoc/2.3.2/) result 301).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).